### PR TITLE
fix Socket::to() method - emit to selected room

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -141,9 +141,9 @@ public function __destruct()
     
     public function to($name)
     {
-        if(!isset($this->rooms[$name]))
+        if(!isset($this->_rooms[$name]))
         {
-            $this->rooms[$name] = $name;
+            $this->_rooms[$name] = $name;
         }
         return $this;
     }


### PR DESCRIPTION
Socket::emit() method check the property Socket::**_root**, and in Socket::to() method specified property Socket::**root**. This does not work to send the events in a certain rooms.