### PR TITLE
ORIGIN work http://domain1 http://domain2 now

### DIFF
--- a/src/Engine/Engine.php
+++ b/src/Engine/Engine.php
@@ -98,7 +98,7 @@ public function __destruct()
             $headers['Access-Control-Allow-Origin'] = '*';
         }
 
-        $res->writeHead(400, '', $headers);
+        $res->writeHead(403, '', $headers);
         $res->end(json_encode(array(
             'code' => $code,
             'message' => isset(self::$errorMessages[$code]) ? self::$errorMessages[$code] : $code
@@ -161,12 +161,15 @@ public function __destruct()
             $parts = parse_url($origin);
             $defaultPort = 'https:' === $parts['scheme'] ? 443 : 80;
             $parts['port'] = isset($parts['port']) ? $parts['port'] : $defaultPort;
-            $ok =
-                $this->origins === $parts['scheme'] . '://' . $parts['host'] . ':' . $parts['port'] ||
-                $this->origins === $parts['scheme'] . '://' . $parts['host'] ||
-                $this->origins === $parts['scheme'] . '://' . $parts['host'] . ':*' ||
-                $this->origins === '*:' . $parts['port'];
-            return call_user_func($fn, null, $ok, $req);
+            $allowed_origins = explode(' ', $this->origins);
+            foreach( $allowed_origins as $allow_origin ){
+                $ok =
+                    $allow_origin === $parts['scheme'] . '://' . $parts['host'] . ':' . $parts['port'] ||
+                    $allow_origin === $parts['scheme'] . '://' . $parts['host'] ||
+                    $allow_origin === $parts['scheme'] . '://' . $parts['host'] . ':*' ||
+                    $allow_origin === '*:' . $parts['port'];
+                return call_user_func($fn, null, $ok, $req);
+            }
         }
         call_user_func($fn, null, false, $req);
     }


### PR DESCRIPTION
Previous patch would only allow one domain to connect to the project. This patch allow to use any domain you would like to connect to your app. example $io->origins('http://domain1 http://domain2'); or $io->origins('http://domain1:* http://domain2:*'); ..

This patch also add a suitable 403 http code when a domain tries to connect and is not in the allowed domains..

Which is better also for debugging, instead of 400 bad request...