### PR TITLE
Stop warning message on PHPSocketIO\Socket::disconnect()

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -428,7 +428,7 @@ public function __destruct()
      * @api public
      */
     
-    public function disconnect($close)
+    public function disconnect( $close = false )
     {
         if (!$this->connected) return $this;
         if ($close) 


### PR DESCRIPTION
```php

Warning: Missing argument 1 for PHPSocketIO\Socket::disconnect(), called in /php_socket.io/vendor/workerman/phpsocket.io/src/Client.php on line 93 and defined in /php_socket.io/vendor/workerman/phpsocket.io/src/Socket.php on line 431

```

This patch alleviate warning error in production environment..