### PR TITLE
Delete previous ping timer only if exists

### DIFF
--- a/src/Engine/Socket.php
+++ b/src/Engine/Socket.php
@@ -59,7 +59,9 @@ public function __destruct()
         {
             $this->upgradeTransport->send(array(array('type'=> 'pong', 'data'=> 'probe')));
             //$this->transport->shouldClose = function(){};
-            Timer::del($this->checkIntervalTimer);
+            if ($this->checkIntervalTimer) {
+		        Timer::del($this->checkIntervalTimer);
+	        }
             $this->checkIntervalTimer = Timer::add(0.5, array($this, 'check'));
         }
         else if('upgrade' === $packet['type'] && $this->readyState !== 'closed')

--- a/src/Engine/Socket.php
+++ b/src/Engine/Socket.php
@@ -206,7 +206,9 @@ public function __destruct()
     
     public function setPingTimeout()
     {
-        Timer::del($this->pingTimeoutTimer);
+        if ($this->pingTimeoutTimer) {
+            Timer::del($this->pingTimeoutTimer);
+        }
         $this->pingTimeoutTimer = Timer::add(
            $this->server->pingInterval + $this->server->pingTimeout ,
            array($this, 'pingTimeoutCallback'), null, false);


### PR DESCRIPTION
Fixes following error when using React loop
```
Catchable fatal error: Argument 1 passed to React\EventLoop\StreamSelectLoop::cancelTimer() must implement interface React\EventLoop\Timer\TimerInterface, null given
```