### PR TITLE
Make "Upgrade" header value case-insensitive

### DIFF
--- a/src/Engine/Protocols/SocketIO.php
+++ b/src/Engine/Protocols/SocketIO.php
@@ -32,7 +32,7 @@ class SocketIO
         $connection->hasReadedHead = true;
         TcpConnection::$statistics['total_request']++;
         $connection->onClose = '\PHPSocketIO\Engine\Protocols\SocketIO::emitClose';
-        if(isset($req->headers['upgrade']) && $req->headers['upgrade'] == 'websocket')
+        if(isset($req->headers['upgrade']) && strtolower($req->headers['upgrade']) === 'websocket')
         {
             $connection->consumeRecvBuffer(strlen($http_buffer));
             WebSocket::dealHandshake($connection, $req, $res);


### PR DESCRIPTION
Section 4.2.1 of RFC6455 says "An |Upgrade| header field containing the value "websocket", treated as an ASCII case-insensitive value."

Plus, Apache httpd's [mod_proxy_wstunnel](https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html) forward any request with camelcased `Upgrade: WebSocket`, thus break the reverse proxy for phpsocket.io apps.