### PR TITLE
Missing backslash \Exception

### DIFF
--- a/src/Socket.php
+++ b/src/Socket.php
@@ -102,7 +102,7 @@ class Socket extends Emitter
             //{
                 if ($this->_rooms || isset($flags['broadcast']))
                 {
-                    throw new Exception('Callbacks are not supported when broadcasting');
+                    throw new \Exception('Callbacks are not supported when broadcasting');
                 }
                 echo('emitting packet with ack id ' . $this->nsp->ids);
                 $this->acks[$this->nsp->ids] = array_pop($args);


### PR DESCRIPTION
Otherwise you get a namespace error `Attempted to load class "Exception" from namespace "PHPSocketIO".`