### PR TITLE
Fix the namespaces handling

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -193,9 +193,9 @@ public function __destruct()
 
     public function ondecoded($packet) 
     {
-        if(Parser::CONNECT === $packet['type'])
+        if(Parser::CONNECT == $packet['type'])
         {
-            $this->connect($packet->nsp);
+            $this->connect($packet['nsp']);
         } else {
             if(isset($this->nsps[$packet['nsp']])) 
             {


### PR DESCRIPTION
This (small) pull request adjusts the logic of socket.io's **namespaces** handling, and make this thing to work.

To note that I tested this code while writing a PHPSocketIO-based Push Server for Nova Framework, which use those namespaces: https://github.com/nova-framework/quasar

OK, also remove some trailing spaces from code.