### PR TITLE
Cleanup the options for the inner Worker and consolidate the logic for the usage of extended Nsp and Socket classes

### DIFF
--- a/src/Nsp.php
+++ b/src/Nsp.php
@@ -99,7 +99,7 @@ class Nsp extends Emitter
         $args = func_get_args();
         if (isset(self::$events[$ev]))
         {
-            call_user_func_array(array($this, 'parent::emit'), $args);
+            call_user_func_array(array(__CLASS__, 'parent::emit'), $args);
         }
         else
         {

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -87,7 +87,7 @@ class Socket extends Emitter
         $args = func_get_args();
         if (isset(self::$events[$ev]))
         {
-            call_user_func_array(array($this, 'parent::emit'), $args);
+            call_user_func_array(array(__CLASS__, 'parent::emit'), $args);
         }
         else
         {
@@ -304,7 +304,7 @@ class Socket extends Emitter
         {
             $args[] = $this->ack($packet['id']);
         }
-        call_user_func_array(array($this, 'parent::emit'), $args);
+        call_user_func_array(array(__CLASS__, 'parent::emit'), $args);
     }
 
     /**

--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -28,6 +28,8 @@ class SocketIO
             $this->origins($opts['origins']);
         }
 
+        unset($opts['nsp'], $opts['socket'], $opts['adapter'], $opts['origins']);
+
         $this->sockets = $this->of('/');
 
         if(!class_exists('Protocols\SocketIO'))


### PR DESCRIPTION
This pull request cleanup the options in the `PHPSocketIO\SocketIO` for making happy the inner Worker (just unsetting all options used by this very class) and  consolidate the logic for the usage of extended Nsp and Socket classes.

Basically, we will hit a loop (ending sometimes on a worker crash) when we use from an extended class calls like:
```php
call_user_func_array(array($this, 'parent::emit'), $args);
```
There the `$this` points to the instantiated class, i.e. `Quasar\Platform\SocketIO\Nsp` and we do the call right on its parent: `PHPSocketIO\Nsp`, resulting in the method's recursive call of itself.

The proper/working call should be like
```php
call_user_func_array(array(__CLASS__, 'parent::emit'), $args);
```
which is equivalent with
```php
call_user_func_array(array('PHPSocketIO\Nsp', 'parent::emit'), $args);
```
To note that since PHP 5.3 the `$this` will propagate automatically through.