### PR TITLE
Expose the inner Worker's onWorkerStop callback

### DIFF
--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -133,12 +133,15 @@ class SocketIO
 
     public function on()
     {
-        if(func_get_arg(0) === 'workerStart')
-        {
-           $this->worker->onWorkerStart = func_get_arg(1);
-           return;
+        $args = array_pad(func_get_args(), 2, null);
+
+        if ($args[0] === 'workerStart') {
+           $this->worker->onWorkerStart = $args[1];
+        } else if ($args[0] === 'workerStop') {
+           $this->worker->onWorkerStop = $args[1];
+        } else if ($args[0] !== null) {
+            return call_user_func_array(array($this->sockets, 'on'), $args);
         }
-        return call_user_func_array(array($this->sockets, 'on'), func_get_args());
     }
 
     public function in()


### PR DESCRIPTION
This pull request expose the inner Worker's `onWorkerStop` callback in a similar way with the starting callback: `onWorkerStart`

The usefulness of this feature is for executing certain tasks when the inner Worker instance is about to stop, for example to save statistics to database, etc...

The usage is something like:
```php
$socketIo->on('workerStop', function ()
{
    // The inner Worker is about to stop - time to save the essential information.
});
```  
Basically, it is the counterpart of `$socketIo->on('workerStart', function () {});` 