### PR TITLE
Fixed a broken path in demo workers

### DIFF
--- a/examples/chat/start_io.php
+++ b/examples/chat/start_io.php
@@ -5,7 +5,7 @@ use Workerman\Autoloader;
 use PHPSocketIO\SocketIO;
 
 // composer autoload
-require_once __DIR__ . '/../../../../../vendor/autoload.php';
+require_once join(DIRECTORY_SEPARATOR, [__DIR__, "..", "..", "vendor", "autoload.php"]);
 
 $io = new SocketIO(2020);
 $io->on('connection', function($socket){

--- a/examples/chat/start_web.php
+++ b/examples/chat/start_web.php
@@ -5,7 +5,7 @@ use Workerman\Autoloader;
 use PHPSocketIO\SocketIO;
 
 // composer autoload
-require_once  __DIR__ . '/../../../../../vendor/autoload.php';
+require_once join(DIRECTORY_SEPARATOR, [__DIR__, "..", "..", "vendor", "autoload.php"]);
 
 $web = new WebServer('http://0.0.0.0:2022');
 $web->addRoot('localhost', __DIR__ . '/public');


### PR DESCRIPTION
I only fixed the php lines that load composer's autoloader in both start_io and start_web php files in exemples/chat folder. 

