### PR TITLE
PHP 5.3 syntax and tests/emitter.php fix

### DIFF
--- a/examples/chat/start_io.php
+++ b/examples/chat/start_io.php
@@ -5,12 +5,11 @@ use Workerman\Autoloader;
 use PHPSocketIO\SocketIO;
 
 // composer autoload
-require_once join(DIRECTORY_SEPARATOR, [__DIR__, "..", "..", "vendor", "autoload.php"]);
+require_once join(DIRECTORY_SEPARATOR, array(__DIR__, "..", "..", "vendor", "autoload.php"));
 
 $io = new SocketIO(2020);
 $io->on('connection', function($socket){
     $socket->addedUser = false;
-
     // when the client emits 'new message', this listens and executes
     $socket->on('new message', function ($data)use($socket){
         // we tell the client to execute 'new message'

--- a/examples/chat/start_web.php
+++ b/examples/chat/start_web.php
@@ -5,7 +5,7 @@ use Workerman\Autoloader;
 use PHPSocketIO\SocketIO;
 
 // composer autoload
-require_once join(DIRECTORY_SEPARATOR, [__DIR__, "..", "..", "vendor", "autoload.php"]);
+require_once join(DIRECTORY_SEPARATOR, array(__DIR__, "..", "..", "vendor", "autoload.php"));
 
 $web = new WebServer('http://0.0.0.0:2022');
 $web->addRoot('localhost', __DIR__ . '/public');

--- a/src/Event/Emitter.php
+++ b/src/Event/Emitter.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHPSocketIO\Event;
-use \PHPSocketIO\Debug;
+
+use PHPSocketIO\Debug;
+
 class Emitter
 {
     public function __construct()

--- a/tests/emitter.php
+++ b/tests/emitter.php
@@ -1,5 +1,8 @@
 <?php
-include __DIR__.'/../src/Event/Emitter.php';
+$rootPath = join(DIRECTORY_SEPARATOR, array(__DIR__,".."));
+include join(DIRECTORY_SEPARATOR, array($rootPath,"vendor","autoload.php"));
+include join(DIRECTORY_SEPARATOR, array($rootPath,"src","Event","Emitter.php"));
+
 ini_set('display_errors', 'on');
 $emitter = new PHPSocketIO\Event\Emitter;
 $func = function($arg1, $arg2)


### PR DESCRIPTION
Here are the two commands that I used to test my changes : 
`php examples/chat/start_web.php examples/chat/start_io.php` In order to test the demo  
`php tests/emitter.php` In order to test the tests/emitter.php file


