### PR TITLE
Supplement the previous commit of "fix timer".

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://www.workerman.net",
     "license" : "MIT",
     "require": {
-        "workerman/workerman" : ">=3.5.16",
+        "workerman/workerman" : ">=4.0.0",
         "workerman/channel" : ">=1.0.0"
     },
     "autoload": {


### PR DESCRIPTION
As workerman 3.5+ does not have \Workerman\Timer. Supplement the previous commit of [fix timer](https://github.com/walkor/phpsocket.io/commit/2c8bce9091bbef99e4122454973fbeb393e86c80)