### PR TITLE
php8.2 fixed bug

### DIFF
--- a/src/Engine/Protocols/Http/Request.php
+++ b/src/Engine/Protocols/Http/Request.php
@@ -24,6 +24,10 @@ class Request
 
     public $_query = null;
 
+    public $res = null;
+
+    public $cleanup = null;
+
     public function __construct($connection, $raw_head)
     {
         $this->connection = $connection;

--- a/src/Engine/Transports/PollingXHR.php
+++ b/src/Engine/Transports/PollingXHR.php
@@ -6,6 +6,8 @@ use PHPSocketIO\Debug;
 
 class PollingXHR extends Polling
 {
+    public $sid = null;
+
     public function __construct()
     {
         Debug::debug('PollingXHR __construct');

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -26,6 +26,9 @@ class Socket extends Emitter
     public $handshake = [];
     public $userId = null;
     public $isGuest = false;
+    public $addedUser = null;
+    public $username = null;
+
 
     public static $events = [
         'error' => 'error',


### PR DESCRIPTION
Deprecated: Creation of dynamic property PHPSocketIO\Engine\Protocols\Http\Request::$res is deprecated
Deprecated: Creation of dynamic property PHPSocketIO\Engine\Transports\PollingXHR::$sid is deprecated
Deprecated: Creation of dynamic property PHPSocketIO\Engine\Protocols\Http\Request::$cleanup
Deprecated: Creation of dynamic property PHPSocketIO\Socket::$addedUser is deprecated
Deprecated: Creation of dynamic property PHPSocketIO\Socket::$username is deprecated