### PR TITLE
feat: add support to ipv6.

### DIFF
--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -39,7 +39,7 @@ class SocketIO
             class_alias('PHPSocketIO\Engine\Protocols\SocketIO', 'Protocols\SocketIO');
         }
         if ($port) {
-            $host = $opts['host'] ?? '0.0.0.0';
+            $host = filter_var(trim($opts['host'] ?? '0.0.0.0', '[]'), FILTER_VALIDATE_IP) ?: '0.0.0.0';
             $worker = new Worker('SocketIO://' . $host . ':' . $port, $opts);
             $worker->name = 'PHPSocketIO';
 

--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -39,7 +39,7 @@ class SocketIO
             class_alias('PHPSocketIO\Engine\Protocols\SocketIO', 'Protocols\SocketIO');
         }
         if ($port) {
-            $worker = new Worker('SocketIO://0.0.0.0:' . $port, $opts);
+            $worker = new Worker('SocketIO://[::]:' . $port, $opts);
             $worker->name = 'PHPSocketIO';
 
             if (isset($opts['ssl'])) {

--- a/src/SocketIO.php
+++ b/src/SocketIO.php
@@ -39,7 +39,8 @@ class SocketIO
             class_alias('PHPSocketIO\Engine\Protocols\SocketIO', 'Protocols\SocketIO');
         }
         if ($port) {
-            $worker = new Worker('SocketIO://[::]:' . $port, $opts);
+            $host = $opts['host'] ?? '0.0.0.0';
+            $worker = new Worker('SocketIO://' . $host . ':' . $port, $opts);
             $worker->name = 'PHPSocketIO';
 
             if (isset($opts['ssl'])) {


### PR DESCRIPTION
Hello @walkor!

Currently, the Socket is only created for IPV4 connections, using `0.0.0.0`, thus without IPV6 support.

Adding `[::]` will work with both protocols.

I'm not sure if this is the best change for this case, I'll be validating it in my application in the next few days.

But I've already opened this MR for discussion, have you raised anything about this?