### PR TITLE
docs: add license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 walkor<walkor@workerman.net> and contributors (see https://github.com/walkor/webman/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2015 walkor<walkor@workerman.net> and contributors (see https://github.com/walkor/webman/contributors)
+Copyright (c) 2015 walkor<walkor@workerman.net> and contributors (see https://github.com/walkor/phpsocket.io/graphs/contributors)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi, I got here through @marcosmarcolin in https://github.com/wellwelwel/awesomeyou/pull/29.

This _PR_ adds the `LICENSE` file to improve the information about the repository and reinforce the project license already present in [README#license](https://github.com/walkor/phpsocket.io?tab=readme-ov-file#license).

For example, trying to use **shields.io**:

> <img width="152" alt="Screenshot 2025-04-08 at 05 14 20" src="https://github.com/user-attachments/assets/38ec6e9c-da00-4af3-990d-c435607eebcb" />

Also for the summary in the repository's sidebar:

> <img width="152" alt="Screenshot 2025-04-08 at 05 15 37" src="https://github.com/user-attachments/assets/642df0a1-9694-4ba7-8bbc-6988b26a761b" />

And the README _navbar_:

> <img width="410" alt="Screenshot 2025-04-08 at 05 29 06" src="https://github.com/user-attachments/assets/bf3213a9-240e-4426-8698-c71ab8708db4" />


---

> [!NOTE]
>
> I just copied/pasted the license file from [**walkor/webman**](https://github.com/walkor/webman/blob/e2a16ab5b271e1154570c7076068548d2d0ce659/LICENSE) and based the year on the [first commit](https://github.com/walkor/phpsocket.io/commit/62f36e58c79ec19d9b75351f1919dcee93201022) of **phpsocket.io**.