### PR TITLE
fix: include error message and add descriptive details to TransportError 

### DIFF
--- a/src/Engine/Socket.php
+++ b/src/Engine/Socket.php
@@ -59,7 +59,7 @@ class Socket extends Emitter
     public function onUpgradePacket(array $packet): void
     {
         if (empty($this->upgradeTransport)) {
-            $this->onError('upgradeTransport empty');
+            $this->onError('Upgrade transport is not available or was already cleared');
             return;
         }
         if ('ping' === $packet['type'] && (isset($packet['data']) && 'probe' === $packet['data'])) {
@@ -103,7 +103,7 @@ class Socket extends Emitter
 
     public function onUpgradeTransportClose(): void
     {
-        $this->onUpgradeTransportError('transport closed');
+        $this->onUpgradeTransportError('Upgrade transport closed unexpectedly');
     }
 
     public function onUpgradeTransportError($err): void

--- a/src/Engine/Transport.php
+++ b/src/Engine/Transport.php
@@ -41,7 +41,7 @@ class Transport extends Emitter
     public function onError(string $msg, string $desc = '')
     {
         if ($this->listeners('error')) {
-            $this->emit('error', "TransportError: {$desc}");
+            $this->emit('error', "TransportError: {$msg}" . ($desc ? " - {$desc}" : ''));
         } else {
             echo("ignored transport error $msg $desc\n");
         }

--- a/src/Engine/Transports/Polling.php
+++ b/src/Engine/Transports/Polling.php
@@ -32,7 +32,7 @@ class Polling extends Transport
     public function onPollRequest(object $req, object $res): void
     {
         if ($this->req) {
-            $this->onError('overlap from client');
+            $this->onError('Overlap from client', 'A poll request already exists for this transport');
             $res->writeHead(500);
             return;
         }
@@ -54,7 +54,7 @@ class Polling extends Transport
 
     public function pollRequestOnClose(): void
     {
-        $this->onError('poll connection closed prematurely');
+        $this->onError('Poll connection closed prematurely', 'Client disconnected before poll response was sent');
         $this->pollRequestClean();
     }
 
@@ -69,7 +69,7 @@ class Polling extends Transport
     public function onDataRequest($req, $res): void
     {
         if (isset($this->dataReq)) {
-            $this->onError('data request overlap from client');
+            $this->onError('Data request overlap from client', 'A data request already exists for this transport');
             $res->writeHead(500);
             return;
         }
@@ -91,7 +91,7 @@ class Polling extends Transport
     public function dataRequestOnClose(): void
     {
         $this->dataRequestCleanup();
-        $this->onError('data request connection closed prematurely');
+        $this->onError('Data request connection closed prematurely', 'Client disconnected before data request completed');
     }
 
     public function dataRequestOnData($req, $data): void


### PR DESCRIPTION
The `onError` method was emitting only `$desc`, ignoring the main `$msg` parameter. Now both are included in the emitted string.                                                                                                                                                                      
                                                                                                                                                                                                                                 
Additionally, all `onError` calls in `Polling` now pass a `$desc` with  a human-readable explanation, making it easier to diagnose transport errors on the client side. 